### PR TITLE
Add support for STOMP heartbeats to raw Websocket endpoint

### DIFF
--- a/src/rabbit_ws_handler.erl
+++ b/src/rabbit_ws_handler.erl
@@ -41,9 +41,10 @@ websocket_init(_TransportName, Req, [{type, FrameType}]) ->
     [Socket, Transport] = cowboy_req:get([socket, transport], Req),
     {ok, Sockname} = Transport:sockname(Socket),
     Conn = {?MODULE, self(), [
+        {socket, Socket},
         {peername, Peername},
         {sockname, Sockname}]},
-    {ok, _Sup, Pid} = rabbit_ws_sup:start_client({Conn}),
+    {ok, _Sup, Pid} = rabbit_ws_sup:start_client({Conn, heartbeat}),
     {ok, Req, #state{pid=Pid, type=FrameType}}.
 
 websocket_handle({text, Data}, Req, State=#state{pid=Pid}) ->

--- a/src/rabbit_ws_sockjs.erl
+++ b/src/rabbit_ws_sockjs.erl
@@ -82,7 +82,7 @@ logger(_Service, Req, _Type) ->
 %% --------------------------------------------------------------------------
 
 service_stomp(Conn, init, _State) ->
-    {ok, _Sup, Pid} = rabbit_ws_sup:start_client({Conn}),
+    {ok, _Sup, Pid} = rabbit_ws_sup:start_client({Conn, no_heartbeat}),
     {ok, Pid};
 
 service_stomp(_Conn, {recv, Data}, Pid) ->


### PR DESCRIPTION
Works with the examples, can try to add a test if needed.

Fixes #15.