### PR TITLE
Completely disable heartbeats for SockJS

### DIFF
--- a/src/rabbit_ws_client_sup.erl
+++ b/src/rabbit_ws_client_sup.erl
@@ -61,7 +61,7 @@ start_proc(SupPid, Conn, Heartbeat) ->
                                            SendFin, ReceiveTimeout, ReceiveFun)
             end;
         no_heartbeat ->
-            fun (_, _, _, _) -> ok end
+            undefined
     end,
 
     {ok, Processor} =


### PR DESCRIPTION
Before the heartbeats start fun would do nothing but the server
would still tell the client heartbeats were enabled, leading to
issues with default client options. Now, we provide 'undefined'
instead of a start fun and the processor sends 0,0 back to the
client instead of an incorrect value.

Fix for https://github.com/rabbitmq/rabbitmq-web-stomp/issues/28