### PR TITLE
Add use_http_auth option to enable HTTP Basic Auth

### DIFF
--- a/src/rabbit_ws_handler.erl
+++ b/src/rabbit_ws_handler.erl
@@ -40,10 +40,15 @@ websocket_init(_TransportName, Req, [{type, FrameType}]) ->
     {Peername, _} = cowboy_req:peer(Req),
     [Socket, Transport] = cowboy_req:get([socket, transport], Req),
     {ok, Sockname} = Transport:sockname(Socket),
+    Headers = case cowboy_req:header(<<"authorization">>, Req) of
+        {undefined, _} -> [];
+        {AuthHd, _}    -> [{authorization, binary_to_list(AuthHd)}]
+    end,
     Conn = {?MODULE, self(), [
         {socket, Socket},
         {peername, Peername},
-        {sockname, Sockname}]},
+        {sockname, Sockname},
+        {headers, Headers}]},
     {ok, _Sup, Pid} = rabbit_ws_sup:start_client({Conn, heartbeat}),
     {ok, Req, #state{pid=Pid, type=FrameType}}.
 

--- a/src/rabbitmq_web_stomp.app.src
+++ b/src/rabbitmq_web_stomp.app.src
@@ -12,6 +12,7 @@
          {num_ssl_acceptors, 1},
          {cowboy_opts, []},
          {sockjs_opts, []},
-         {ws_frame, text}]},
+         {ws_frame, text},
+         {use_http_auth, false}]},
   {applications, [kernel, stdlib, rabbit, rabbitmq_stomp, cowboy, sockjs]}
  ]}.

--- a/test/src/rabbit_ws_test_raw_websocket.erl
+++ b/test/src/rabbit_ws_test_raw_websocket.erl
@@ -69,3 +69,35 @@ disconnect_test() ->
     {close, {1000, _}} = rfc6455_client:recv(WS),
 
     ok.
+
+http_auth_test() ->
+    ok = application:set_env(rabbitmq_web_stomp, use_http_auth, true),
+    ok = application:stop(rabbitmq_web_stomp),
+    ok = cowboy:stop_listener(http),
+    ok = application:start(rabbitmq_web_stomp),
+
+    %% Intentionally put bad credentials in the CONNECT frame,
+    %% and good credentials in the Authorization header, to
+    %% confirm that the right credentials are picked.
+    WS = rfc6455_client:new("ws://127.0.0.1:15674/stomp/websocket", self(),
+        [{login, "guest"}, {passcode, "guest"}]),
+    {ok, _} = rfc6455_client:open(WS),
+    ok = raw_send(WS, "CONNECT", [{"login", "bad"}, {"passcode", "bad"}]),
+    {<<"CONNECTED">>, _, <<>>} = raw_recv(WS),
+    {close, _} = rfc6455_client:close(WS),
+
+    %% Confirm that if no Authorization header is provided,
+    %% the default STOMP plugin credentials are used. We
+    %% expect an error because the default credentials are
+    %% left undefined.
+    WS2 = rfc6455_client:new("ws://127.0.0.1:15674/stomp/websocket", self()),
+    {ok, _} = rfc6455_client:open(WS2),
+    ok = raw_send(WS2, "CONNECT", [{"login", "bad"}, {"passcode", "bad"}]),
+    {<<"ERROR">>, _, _} = raw_recv(WS2),
+    {close, _} = rfc6455_client:close(WS2),
+
+    %% Set auth option back to default and restart the web stomp application.
+    ok = application:set_env(rabbitmq_web_stomp, use_http_auth, false),
+    ok = application:stop(rabbitmq_web_stomp),
+    ok = cowboy:stop_listener(http),
+    ok = application:start(rabbitmq_web_stomp).


### PR DESCRIPTION
The intended behavior is to use the login/passcode found
in the Authorization header, if any, and otherwise fall
back to the usual authentication methods.

Part of https://github.com/rabbitmq/rabbitmq-web-stomp/issues/43
