### PR TITLE
Fix use of default credentials with use_http_auth

### DIFF
--- a/test/cowboy_websocket_SUITE.erl
+++ b/test/cowboy_websocket_SUITE.erl
@@ -162,8 +162,30 @@ http_auth(Config) ->
     %% the default STOMP plugin credentials are used. We
     %% expect an error because the default credentials are
     %% left undefined.
-    WS2 = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/stomp/websocket", self()),
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                      application, set_env,
+                                      [rabbitmq_stomp, default_user,
+                                        [{login, "bad-default"}, {passcode, "bad-default"}]
+                                      ]),
+
+    WS2 = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws", self()),
     {ok, _} = rfc6455_client:open(WS2),
     ok = raw_send(WS2, "CONNECT", [{"login", "bad"}, {"passcode", "bad"}]),
     {<<"ERROR">>, _, _} = raw_recv(WS2),
-    {close, _} = rfc6455_client:close(WS2).
+    {close, _} = rfc6455_client:close(WS2),
+
+    %% Confirm that we can connect if the default STOMP
+    %% credentials are used.
+    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
+                                      application, set_env,
+                                      [rabbitmq_stomp, default_user,
+                                        [{login, "guest"}, {passcode, "guest"}]
+                                      ]),
+
+    WS3 = rfc6455_client:new("ws://127.0.0.1:" ++ PortStr ++ "/ws", self()),
+    {ok, _} = rfc6455_client:open(WS3),
+    ok = raw_send(WS3, "CONNECT", [{"login", "bad"}, {"passcode", "bad"}]),
+    {<<"CONNECTED">>, _, <<>>} = raw_recv(WS3),
+    {close, _} = rfc6455_client:close(WS3),
+
+    ok.


### PR DESCRIPTION
When HTTP authorization header is not sent, we use the default
credentials defined in the rabbitmq_stomp configuration.

Fixes https://github.com/rabbitmq/rabbitmq-web-stomp/issues/60.

Also see https://github.com/rabbitmq/rabbitmq-stomp/pull/96.