### PR TITLE
Support typical RabbitMQ TCP socket options

### DIFF
--- a/src/rabbit_ws_sockjs.erl
+++ b/src/rabbit_ws_sockjs.erl
@@ -18,6 +18,9 @@
 
 -export([init/0]).
 
+%% for testing purposes
+-export([get_binding_address/1, get_tcp_port/1, get_tcp_conf/2]).
+
 -include_lib("rabbitmq_stomp/include/rabbit_stomp.hrl").
 
 
@@ -25,16 +28,9 @@
 
 -spec init() -> ok.
 init() ->
-    %% The 'tcp_config' option may include the port, but we already have
-    %% a 'port' option, so we prioritize the 'port' option over the one
-    %% found in 'tcp_config', if any.
-    TCPConf0 = get_env(tcp_config, []),
-    {TCPConf, Port} = case application:get_env(rabbitmq_web_stomp, port) of
-        undefined ->
-            {TCPConf0, proplists:get_value(port, TCPConf0, 15674)};
-        {ok, Port0} ->
-            {[{port, Port0}|TCPConf0], Port0}
-    end,
+    Port = get_tcp_port(application:get_all_env(rabbitmq_web_stomp)),
+
+    TcpConf = get_tcp_conf(get_env(tcp_config, []), Port),
 
     WsFrame = get_env(ws_frame, text),
     CowboyOpts = get_env(cowboy_opts, []),
@@ -53,27 +49,28 @@ init() ->
         {ok, NumTcp}  -> NumTcp
     end,
     {ok, _} = cowboy:start_http(http, NumTcpAcceptors,
-                                TCPConf,
+                                TcpConf,
                                 [{env, [{dispatch, Routes}]}|CowboyOpts]),
-    listener_started('http/web-stomp', TCPConf),
+    listener_started('http/web-stomp', TcpConf),
     rabbit_log:info("rabbit_web_stomp: listening for HTTP connections on ~s:~w~n",
-                    ["0.0.0.0", Port]),
+                    [get_binding_address(TcpConf), Port]),
     case get_env(ssl_config, []) of
         [] ->
             ok;
         TLSConf ->
             rabbit_networking:ensure_ssl(),
             TLSPort = proplists:get_value(port, TLSConf),
+            TLSConfWithParsedIp = maybe_parse_ip(TLSConf),
             NumSslAcceptors = case application:get_env(rabbitmq_web_stomp, num_ssl_acceptors) of
                 undefined -> get_env(num_acceptors, 1);
                 {ok, NumSsl}  -> NumSsl
             end,
             {ok, _} = cowboy:start_https(https, NumSslAcceptors,
-                                         TLSConf,
+                                         TLSConfWithParsedIp,
                                          [{env, [{dispatch, Routes}]}|CowboyOpts]),
-            listener_started('https/web-stomp', TCPConf),
+            listener_started('https/web-stomp', TLSConfWithParsedIp),
             rabbit_log:info("rabbit_web_stomp: listening for HTTPS connections on ~s:~w~n",
-                            ["0.0.0.0", TLSPort])
+                            [get_binding_address(TLSConfWithParsedIp), TLSPort])
     end,
     ok.
 
@@ -91,6 +88,43 @@ get_env(Key, Default) ->
         {ok, V}   -> V
     end.
 
+
+get_tcp_port(Configuration) ->
+    %% The 'tcp_config' option may include the port, and we already have
+    %% a 'port' option. We prioritize the 'port' option  in 'tcp_config' (if any)
+    %% over the one found at the root of the env proplist.
+    TcpConfiguration = proplists:get_value(tcp_config, Configuration, []),
+    case proplists:get_value(port, TcpConfiguration) of
+        undefined ->
+            proplists:get_value(port, Configuration, 15674);
+        Port ->
+            Port
+    end.
+
+get_tcp_conf(TcpConfiguration, Port) ->
+    TcpConfigurationWithFinalPort = [{port, Port}|proplists:delete(port, TcpConfiguration)],
+    maybe_parse_ip(TcpConfigurationWithFinalPort).
+
+maybe_parse_ip(Configuration) ->
+    case proplists:get_value(ip, Configuration) of
+        undefined ->
+            Configuration;
+        IP when is_tuple(IP) ->
+            Configuration;
+        IP when is_list(IP) ->
+            {ok, ParsedIP} = inet_parse:address(IP),
+            [{ip, ParsedIP}|proplists:delete(ip, Configuration)]
+    end.
+
+get_binding_address(Configuration) ->
+    case proplists:get_value(ip, Configuration) of
+        undefined ->
+            "0.0.0.0";
+        IP when is_tuple(IP) ->
+            inet:ntoa(IP);
+        IP when is_list(IP) ->
+            IP
+    end.
 
 %% Don't print sockjs logs
 logger(_Service, Req, _Type) ->

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -1,0 +1,67 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(unit_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+        get_tcp_conf,
+        get_tcp_port,
+        get_binding_address
+    ].
+
+
+%% -------------------------------------------------------------------
+%% Testsuite setup/teardown.
+%% -------------------------------------------------------------------
+
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, Config) ->
+    Config.
+
+%% -------------------------------------------------------------------
+%% Testcases.
+%% -------------------------------------------------------------------
+
+get_tcp_conf(_Config) ->
+    [{ip, {127, 0, 0, 1}}, {port, 15674}] = lists:sort(rabbit_ws_sockjs:get_tcp_conf(
+        [{ip, {127, 0, 0, 1}}, {port, 1245}], 15674
+    )),
+    [{ip, {127, 0, 0, 1}}, {port, 15674}] = lists:sort(rabbit_ws_sockjs:get_tcp_conf(
+        [{ip, {127, 0, 0, 1}}], 15674
+    )),
+    [{port, 15674}] = lists:sort(rabbit_ws_sockjs:get_tcp_conf(
+        [], 15674
+    )),
+    ok.
+
+get_tcp_port(_Config) ->
+    15674 = rabbit_ws_sockjs:get_tcp_port([{port, 15674}]),
+    15674 = rabbit_ws_sockjs:get_tcp_port([{port, 15674}, {tcp_config, []}]),
+    12345 = rabbit_ws_sockjs:get_tcp_port([{port, 15674}, {tcp_config, [{port, 12345}]}]),
+    ok.
+
+get_binding_address(_Config) ->
+    "0.0.0.0" = rabbit_ws_sockjs:get_binding_address([]),
+    "192.168.1.10" = rabbit_ws_sockjs:get_binding_address([{ip, "192.168.1.10"}]),
+    "192.168.1.10" = rabbit_ws_sockjs:get_binding_address([{ip, {192, 168, 1, 10}}]),
+    ok.


### PR DESCRIPTION
The port option in the tcp_options entry takes now precedence
explicitly over the port option at the root of the env proplist.
It was previously the case, even if the opposite was advertized:
there would be 2 port entries in the Ranch options and Ranch
would take the one from tcp_options.

It's now possible to use strings for IP addresses, not only tuples.

The correct binding address and port are now used in the log message.

Fixes #69