### PR TITLE
Do not emit stats if connection has not been stablished

### DIFF
--- a/src/rabbit_ws_client.erl
+++ b/src/rabbit_ws_client.erl
@@ -244,6 +244,11 @@ maybe_emit_stats(State) ->
     rabbit_event:if_enabled(State, #state.stats_timer,
                                 fun() -> emit_stats(State) end).
 
+emit_stats(State=#state{connection = C}) when C == none; C == undefined ->
+    %% Avoid emitting stats on terminate when the connection has not yet been
+    %% established, as this causes orphan entries on the stats database
+    State1 = rabbit_event:reset_stats_timer(State, #state.stats_timer),
+    State1;
 emit_stats(State=#state{conn=Conn, connection=ConnPid}) ->
     Info = Conn:info(),
     Sock = proplists:get_value(socket, Info),


### PR DESCRIPTION
Stats should not be emitted until the connection is stablished - that is,
the initial value 'none' is overridden. A non-pid value crashes the stats gc.

Part of https://github.com/rabbitmq/rabbitmq-management-agent/issues/42