### PR TITLE
allow websocket compression extension

### DIFF
--- a/priv/schema/rabbitmq_web_stomp.schema
+++ b/priv/schema/rabbitmq_web_stomp.schema
@@ -77,3 +77,5 @@
     [{datatype, integer}]}.
 {mapping, "web_stomp.cowboy_opts.timeout", "rabbitmq_web_stomp.cowboy_opts.timeout",
     [{datatype, integer}]}.
+{mapping, "web_stomp.cowboy_opts.compress", "rabbitmq_web_stomp.cowboy_ws_opts.compress",
+    [{datatype, {enum, [true, false]}}]}.

--- a/src/rabbit_ws_handler.erl
+++ b/src/rabbit_ws_handler.erl
@@ -52,7 +52,8 @@ init(Req0, Opts) ->
         undefined -> [];
         AuthHd    -> [{authorization, binary_to_list(AuthHd)}]
     end,
-    {cowboy_websocket, Req, {Socket, Peername, Sockname, Headers, FrameType}}.
+    {_, WsOpts} = lists:keyfind(ws_opts, 1, Opts),
+    {cowboy_websocket, Req, {Socket, Peername, Sockname, Headers, FrameType}, WsOpts}.
 
 websocket_init({Socket, Peername, Sockname, Headers, FrameType}) ->
     Info = [{socket, Socket},

--- a/src/rabbit_ws_listener.erl
+++ b/src/rabbit_ws_listener.erl
@@ -34,9 +34,10 @@ init() ->
 
     WsFrame = get_env(ws_frame, text),
     CowboyOpts = maps:from_list(get_env(cowboy_opts, [])),
+    CowboyWsOpts = maps:from_list(get_env(cowboy_ws_opts, [])),
 
     VhostRoutes = [
-        {get_env(ws_path, "/ws"), rabbit_ws_handler, [{type, WsFrame}]}
+        {get_env(ws_path, "/ws"), rabbit_ws_handler, [{type, WsFrame}, {ws_opts, CowboyWsOpts}]}
     ],
     Routes = cowboy_router:compile([{'_',  VhostRoutes}]), % any vhost
     NumTcpAcceptors = case application:get_env(rabbitmq_web_stomp, num_tcp_acceptors) of


### PR DESCRIPTION
Allow to configure websocket compression extension, which is already supported by cowboy. STOMP frame is highly compressible in many cases because of repetitive headers, so websocket compression is quite beneficial.

In my application, average packet size is reduced by about factor of five. Here's a tcpdump capture of rabbitmq stomp-over-websocket traffic with/without compression

without compression
```
03:29:46.779786 IP 10.0.x.x.50812 > 10.0.x.x.15674: Flags [P.], seq 3197:3355, ack 8634, win 510, length 158
03:29:46.779997 IP 10.0.x.x.15674 > 10.0.x.x.51062: Flags [P.], seq 5412:5662, ack 3717, win 406, length 250
03:29:46.780008 IP 10.0.x.x.15674 > 10.0.x.x.50812: Flags [P.], seq 8634:8885, ack 3355, win 1452, length 251
03:29:46.788706 IP 10.0.x.x.51062 > 10.0.x.x.15674: Flags [P.], seq 3717:3867, ack 5662, win 509, length 150
03:29:46.789007 IP 10.0.x.x.15674 > 10.0.x.x.50812: Flags [P.], seq 8885:9128, ack 3355, win 1452, length 243
03:29:46.794968 IP 10.0.x.x.50812 > 10.0.x.x.15674: Flags [.], ack 9128, win 508, length 0
03:29:46.797619 IP 10.0.x.x.50812 > 10.0.x.x.15674: Flags [P.], seq 3355:3513, ack 9128, win 508, length 158
03:29:46.797956 IP 10.0.x.x.15674 > 10.0.x.x.51062: Flags [P.], seq 5662:5912, ack 3867, win 416, length 250
03:29:46.797973 IP 10.0.x.x.15674 > 10.0.x.x.50812: Flags [P.], seq 9128:9379, ack 3513, win 1452, length 251
03:29:46.807970 IP 10.0.x.x.51062 > 10.0.x.x.15674: Flags [P.], seq 3867:4017, ack 5912, win 508, length 150
03:29:46.807983 IP 10.0.x.x.51062 > 10.0.x.x.15674: Flags [P.], seq 4017:4167, ack 5912, win 508, length 150
03:29:46.808032 IP 10.0.x.x.15674 > 10.0.x.x.51062: Flags [.], ack 4167, win 435, length 0
03:29:46.808427 IP 10.0.x.x.15674 > 10.0.x.x.50812: Flags [P.], seq 9379:9622, ack 3513, win 1452, length 243
03:29:46.808603 IP 10.0.x.x.15674 > 10.0.x.x.50812: Flags [P.], seq 9622:9865, ack 3513, win 1452, length 243
03:29:46.812987 IP 10.0.x.x.50812 > 10.0.x.x.15674: Flags [.], ack 9622, win 512, length 0
03:29:46.815265 IP 10.0.x.x.50812 > 10.0.x.x.15674: Flags [P.], seq 3513:3671, ack 9865, win 511, length 158
03:29:46.815277 IP 10.0.x.x.50812 > 10.0.x.x.15674: Flags [P.], seq 3671:3829, ack 9865, win 511, length 158
03:29:46.815325 IP 10.0.x.x.15674 > 10.0.x.x.50812: Flags [.], ack 3829, win 1452, length 0
```

with compression
```
03:31:10.323705 IP 10.0.x.x.51183 > 10.0.x.x.15674: Flags [P.], seq 1240:1258, ack 891, win 508, length 18
03:31:10.324200 IP 10.0.x.x.15674 > 10.0.x.x.51184: Flags [P.], seq 883:900, ack 1076, win 238, length 17
03:31:10.324228 IP 10.0.x.x.15674 > 10.0.x.x.51183: Flags [P.], seq 891:906, ack 1258, win 248, length 15
03:31:10.329136 IP 10.0.x.x.51184 > 10.0.x.x.15674: Flags [P.], seq 1076:1094, ack 900, win 508, length 18
03:31:10.329344 IP 10.0.x.x.15674 > 10.0.x.x.51183: Flags [P.], seq 906:924, ack 1258, win 248, length 18
03:31:10.335395 IP 10.0.x.x.51183 > 10.0.x.x.15674: Flags [.], ack 924, win 508, length 0
03:31:10.335639 IP 10.0.x.x.51183 > 10.0.x.x.15674: Flags [P.], seq 1258:1276, ack 924, win 508, length 18
03:31:10.335943 IP 10.0.x.x.15674 > 10.0.x.x.51184: Flags [P.], seq 900:917, ack 1094, win 238, length 17
03:31:10.335981 IP 10.0.x.x.15674 > 10.0.x.x.51183: Flags [P.], seq 924:938, ack 1276, win 248, length 14
03:31:10.345107 IP 10.0.x.x.51184 > 10.0.x.x.15674: Flags [P.], seq 1094:1112, ack 917, win 508, length 18
03:31:10.345321 IP 10.0.x.x.15674 > 10.0.x.x.51183: Flags [P.], seq 938:955, ack 1276, win 248, length 17
03:31:10.350579 IP 10.0.x.x.51183 > 10.0.x.x.15674: Flags [.], ack 955, win 508, length 0
03:31:10.352211 IP 10.0.x.x.51183 > 10.0.x.x.15674: Flags [P.], seq 1276:1294, ack 955, win 508, length 18
03:31:10.352466 IP 10.0.x.x.15674 > 10.0.x.x.51184: Flags [P.], seq 917:934, ack 1112, win 238, length 17
03:31:10.352495 IP 10.0.x.x.15674 > 10.0.x.x.51183: Flags [P.], seq 955:969, ack 1294, win 248, length 14
03:31:10.363786 IP 10.0.x.x.51184 > 10.0.x.x.15674: Flags [P.], seq 1112:1130, ack 934, win 508, length 18
03:31:10.364087 IP 10.0.x.x.15674 > 10.0.x.x.51183: Flags [P.], seq 969:987, ack 1294, win 248, length 18
03:31:10.368864 IP 10.0.x.x.51183 > 10.0.x.x.15674: Flags [.], ack 987, win 508, length 0
```

