### PR TITLE
Make it possible to configure more Cowboy WebSocket options

### DIFF
--- a/priv/schema/rabbitmq_web_stomp.schema
+++ b/priv/schema/rabbitmq_web_stomp.schema
@@ -75,8 +75,36 @@
     [{datatype, integer}]}.
 {mapping, "web_stomp.cowboy_opts.max_request_line_length", "rabbitmq_web_stomp.cowboy_opts.max_request_line_length",
     [{datatype, integer}]}.
-{mapping, "web_stomp.cowboy_opts.timeout", "rabbitmq_web_stomp.cowboy_opts.timeout",
-    [{datatype, integer}]}.
+
+%% backwards compatibility
+{mapping, "web_stomp.cowboy_opts.timeout",      "rabbitmq_web_stomp.cowboy_opts.idle_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]
+}.
+%% recent Cowboy versions have several timeout settings
+{mapping, "web_stomp.cowboy_opts.idle_timeout", "rabbitmq_web_stomp.cowboy_opts.idle_timeout",
+    [{datatype, integer}]
+}.
+
+{translation,
+    "rabbitmq_web_stomp.cowboy_opts.idle_timeout",
+    fun(Conf) ->
+        case cuttlefish:conf_get("web_stomp.cowboy_opts.timeout", Conf, undefined) of
+            Value when is_integer(Value) ->
+                Value;
+            undefined ->
+                case cuttlefish:conf_get("web_stomp.cowboy_opts.idle_timeout", Conf, undefined) of
+                    undefined -> cuttlefish:unset();
+                    Value     -> Value
+                end
+        end
+    end
+}.
 
 {mapping, "web_stomp.ws_opts.compress", "rabbitmq_web_stomp.cowboy_ws_opts.compress",
     [{datatype, {enum, [true, false]}}]}.
+{mapping, "web_stomp.ws_opts.max_frame_size", "rabbitmq_web_stomp.cowboy_ws_opts.max_frame_size",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]
+}.
+{mapping, "web_stomp.ws_opts.idle_timeout", "rabbitmq_web_stomp.cowboy_ws_opts.idle_timeout",
+    [{datatype, integer}, {validators, ["non_negative_integer"]}]
+}.

--- a/priv/schema/rabbitmq_web_stomp.schema
+++ b/priv/schema/rabbitmq_web_stomp.schema
@@ -77,7 +77,7 @@
     [{datatype, integer}]}.
 
 %% backwards compatibility
-{mapping, "web_stomp.cowboy_opts.timeout",      "rabbitmq_web_stomp.cowboy_opts.idle_timeout",
+{mapping, "web_stomp.cowboy_opts.timeout", "rabbitmq_web_stomp.cowboy_opts.idle_timeout",
     [{datatype, integer}, {validators, ["non_negative_integer"]}]
 }.
 %% recent Cowboy versions have several timeout settings
@@ -101,7 +101,8 @@
 }.
 
 {mapping, "web_stomp.ws_opts.compress", "rabbitmq_web_stomp.cowboy_ws_opts.compress",
-    [{datatype, {enum, [true, false]}}]}.
+    [{datatype, {enum, [true, false]}}]
+}.
 {mapping, "web_stomp.ws_opts.max_frame_size", "rabbitmq_web_stomp.cowboy_ws_opts.max_frame_size",
     [{datatype, integer}, {validators, ["non_negative_integer"]}]
 }.

--- a/src/rabbit_ws_handler.erl
+++ b/src/rabbit_ws_handler.erl
@@ -52,7 +52,8 @@ init(Req0, Opts) ->
         undefined -> [];
         AuthHd    -> [{authorization, binary_to_list(AuthHd)}]
     end,
-    WsOpts = proplists:get_value(ws_opts, Opts, #{}),
+    WsOpts0 = proplists:get_value(ws_opts, Opts, #{}),
+    WsOpts  = maps:merge(#{compress => true}, WsOpts0),
     {cowboy_websocket, Req, {Socket, Peername, Sockname, Headers, FrameType}, WsOpts}.
 
 websocket_init({Socket, Peername, Sockname, Headers, FrameType}) ->

--- a/src/rabbit_ws_handler.erl
+++ b/src/rabbit_ws_handler.erl
@@ -52,7 +52,7 @@ init(Req0, Opts) ->
         undefined -> [];
         AuthHd    -> [{authorization, binary_to_list(AuthHd)}]
     end,
-    {_, WsOpts} = lists:keyfind(ws_opts, 1, Opts),
+    WsOpts = proplists:get_value(ws_opts, Opts, #{}),
     {cowboy_websocket, Req, {Socket, Peername, Sockname, Headers, FrameType}, WsOpts}.
 
 websocket_init({Socket, Peername, Sockname, Headers, FrameType}) ->

--- a/src/rabbit_ws_listener.erl
+++ b/src/rabbit_ws_listener.erl
@@ -56,7 +56,7 @@ init() ->
         {error, {already_started, _}} -> ok;
         {error, Err}                  ->
             rabbit_log_connection:error(
-                "Failed to start an HTTP listener. Error: ~p,"
+                "Failed to start a WebSocket (HTTP) listener. Error: ~p,"
                 " listener settings: ~p~n",
                 [Err, TcpConf]),
             throw(Err)

--- a/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
@@ -55,6 +55,16 @@
   [{rabbitmq_web_stomp,[{cowboy_opts,[{max_keepalive,10}]}]}],
   [rabbitmq_web_stomp]},
 
+ {cowboy_timeout,
+  "web_stomp.cowboy_opts.timeout = 10000",
+  [{rabbitmq_web_stomp,[{cowboy_opts,[{idle_timeout, 10000}]}]}],
+  [rabbitmq_web_stomp]},
+
+ {cowboy_idle_timeout,
+  "web_stomp.cowboy_opts.idle_timeout = 10000",
+  [{rabbitmq_web_stomp,[{cowboy_opts,[{idle_timeout, 10000}]}]}],
+  [rabbitmq_web_stomp]},
+
  %%
  %% Cowboy WebSocket options
  %%
@@ -67,4 +77,15 @@
 {ws_opts_compress_false,
   "web_stomp.ws_opts.compress = false",
   [{rabbitmq_web_stomp,[{cowboy_ws_opts,[{compress, false}]}]}],
-  [rabbitmq_web_stomp]}].
+  [rabbitmq_web_stomp]},
+
+{ws_opts_max_frame_size,
+  "web_stomp.ws_opts.max_frame_size = 8000",
+  [{rabbitmq_web_stomp,[{cowboy_ws_opts,[{max_frame_size, 8000}]}]}],
+  [rabbitmq_web_stomp]},
+
+{ws_idle_timeout,
+  "web_stomp.ws_opts.idle_timeout = 10000",
+  [{rabbitmq_web_stomp,[{cowboy_ws_opts,[{idle_timeout, 10000}]}]}],
+  [rabbitmq_web_stomp]}
+].


### PR DESCRIPTION
This makes it possible to configure WebSocket options as well as timeouts in modern Cowboy versions (2.4.x in `master` and `v3.7.x`). Per discussion with @lukebakken compression is enabled by default.

To see if compression enabled with various configuration settings, use `rabbitmq_web_stomp_examples`, open an example app and see the `sec-websocket-extensions` request and response headers in browser developer tools.

[#161053760]