### PR TITLE
Use 10 TLS connection acceptors by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ PROJECT_MOD = rabbit_ws_app
 define PROJECT_ENV
 [
 	    {tcp_config, []},
-	    {num_tcp_acceptors, 10},
 	    {ssl_config, []},
-	    {num_ssl_acceptors, 1},
+	    {num_tcp_acceptors, 10},
+	    {num_ssl_acceptors, 10},
 	    {cowboy_opts, []},
 	    {ws_frame, text},
 	    {use_http_auth, false}

--- a/src/rabbit_ws_listener.erl
+++ b/src/rabbit_ws_listener.erl
@@ -73,7 +73,7 @@ init() ->
             TLSPort = proplists:get_value(port, TLSConf0),
             TLSConf = maybe_parse_ip(TLSConf0),
             NumSslAcceptors = case application:get_env(rabbitmq_web_stomp, num_ssl_acceptors) of
-                undefined     -> get_env(num_acceptors, 1);
+                undefined     -> get_env(num_acceptors, 10);
                 {ok, NumSsl}  -> NumSsl
             end,
              {ok, _} = ranch:start_listener(


### PR DESCRIPTION
## Proposed Changes

Bumps number of TLS connection acceptors to 10 by default. See rabbitmq/rabbitmq-server#1729
for context.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue rabbitmq/rabbitmq-server#1729)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-server#1729.

[#161136615]