### PR TITLE
Support more web_stomp.ssl.* options, including cipher suites

### DIFF
--- a/priv/schema/rabbitmq_web_stomp.schema
+++ b/priv/schema/rabbitmq_web_stomp.schema
@@ -63,6 +63,50 @@
     end
 }.
 
+{mapping, "web_stomp.ssl.honor_cipher_order", "rabbitmq_web_stomp.ssl_config.honor_cipher_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "web_stomp.ssl.honor_ecc_order", "rabbitmq_web_stomp.ssl_config.honor_ecc_order",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "web_stomp.ssl.reuse_sessions", "rabbitmq_web_stomp.ssl_config.reuse_sessions",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "web_stomp.ssl.secure_renegotiate", "rabbitmq_web_stomp.ssl_config.secure_renegotiate",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "web_stomp.ssl.client_renegotiation", "rabbitmq_web_stomp.ssl_config.client_renegotiation",
+    [{datatype, {enum, [true, false]}}]}.
+
+{mapping, "web_stomp.ssl.crl_check", "rabbitmq_web_stomp.ssl_config.crl_check",
+    [{datatype, [{enum, [true, false, peer, best_effort]}]}]}.
+
+{mapping, "web_stomp.ssl.depth", "rabbitmq_web_stomp.ssl_config.depth",
+    [{datatype, integer}, {validators, ["byte"]}]}.
+
+{mapping, "web_stomp.ssl.versions.$version", "rabbitmq_web_stomp.ssl_config.versions",
+    [{datatype, atom}]}.
+
+{translation, "rabbitmq_web_stomp.ssl_config.versions",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("web_stomp.ssl.versions", Conf),
+    [V || {_, V} <- Settings]
+end}.
+
+{mapping, "web_stomp.ssl.ciphers.$cipher", "rabbitmq_web_stomp.ssl_config.ciphers",
+    [{datatype, string}]}.
+
+{translation, "rabbitmq_web_stomp.ssl_config.ciphers",
+fun(Conf) ->
+    Settings = cuttlefish_variable:filter_by_prefix("web_stomp.ssl.ciphers", Conf),
+    [V || {_, V} <- Settings]
+end}.
+
+
+%%
+%% Cowboy options
+%%
+
 {mapping, "web_stomp.cowboy_opts.max_empty_lines", "rabbitmq_web_stomp.cowboy_opts.max_empty_lines",
     [{datatype, integer}]}.
 {mapping, "web_stomp.cowboy_opts.max_header_name_length", "rabbitmq_web_stomp.cowboy_opts.max_header_name_length",

--- a/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
@@ -24,7 +24,10 @@
    web_stomp.ssl.certfile   = test/config_schema_SUITE_data/certs/cert.pem
    web_stomp.ssl.keyfile    = test/config_schema_SUITE_data/certs/key.pem
    web_stomp.ssl.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
-   web_stomp.ssl.password   = changeme",
+   web_stomp.ssl.password   = changeme
+
+   web_stomp.ssl.versions.tls1_2 = tlsv1.2
+   web_stomp.ssl.versions.tls1_1 = tlsv1.1",
   [{rabbitmq_web_stomp,
        [{ssl_config,
             [{port,15671},
@@ -32,7 +35,63 @@
              {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
              {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
              {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
-             {password,"changeme"}]}]}],
+             {password,"changeme"},
+
+             {versions,['tlsv1.2','tlsv1.1']}
+            ]}]}],
+  [rabbitmq_web_stomp]},
+
+ {ssl_ciphers,
+  "web_stomp.ssl.port       = 15671
+   web_stomp.ssl.backlog    = 1024
+   web_stomp.ssl.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   web_stomp.ssl.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   web_stomp.ssl.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   web_stomp.ssl.password   = changeme
+
+   web_stomp.ssl.honor_cipher_order   = true
+   web_stomp.ssl.honor_ecc_order      = true
+   web_stomp.ssl.client_renegotiation = false
+   web_stomp.ssl.secure_renegotiate   = true
+
+   web_stomp.ssl.versions.1 = tlsv1.2
+   web_stomp.ssl.versions.2 = tlsv1.1
+   web_stomp.ssl.ciphers.1 = ECDHE-ECDSA-AES256-GCM-SHA384
+   web_stomp.ssl.ciphers.2 = ECDHE-RSA-AES256-GCM-SHA384
+   web_stomp.ssl.ciphers.3 = ECDHE-ECDSA-AES256-SHA384
+   web_stomp.ssl.ciphers.4 = ECDHE-RSA-AES256-SHA384
+   web_stomp.ssl.ciphers.5 = ECDH-ECDSA-AES256-GCM-SHA384
+   web_stomp.ssl.ciphers.6 = ECDH-RSA-AES256-GCM-SHA384
+   web_stomp.ssl.ciphers.7 = ECDH-ECDSA-AES256-SHA384
+   web_stomp.ssl.ciphers.8 = ECDH-RSA-AES256-SHA384
+   web_stomp.ssl.ciphers.9 = DHE-RSA-AES256-GCM-SHA384",
+  [{rabbitmq_web_stomp,
+       [{ssl_config,
+            [{port,15671},
+             {backlog,1024},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {password,"changeme"},
+
+             {honor_cipher_order,   true},
+             {honor_ecc_order,      true},
+             {client_renegotiation, false},
+             {secure_renegotiate,   true},
+
+             {versions,['tlsv1.2','tlsv1.1']},
+             {ciphers, [
+               "DHE-RSA-AES256-GCM-SHA384",
+               "ECDH-ECDSA-AES256-GCM-SHA384",
+               "ECDH-ECDSA-AES256-SHA384",
+               "ECDH-RSA-AES256-GCM-SHA384",
+               "ECDH-RSA-AES256-SHA384",
+               "ECDHE-ECDSA-AES256-GCM-SHA384",
+               "ECDHE-ECDSA-AES256-SHA384",
+               "ECDHE-RSA-AES256-GCM-SHA384",
+               "ECDHE-RSA-AES256-SHA384"
+             ]}
+            ]}]}],
   [rabbitmq_web_stomp]},
 
  {websocket_endpoint,


### PR DESCRIPTION
References rabbitmq/rabbitmq-server#1712, rabbitmq/rabbitmq-server#1745.