### PR TITLE
Support web_stomp.ssl.listener combined with other web_stomp.ssl.* settings

### DIFF
--- a/priv/schema/rabbitmq_web_stomp.schema
+++ b/priv/schema/rabbitmq_web_stomp.schema
@@ -36,15 +36,16 @@
     end
 }.
 
+{mapping, "web_stomp.ssl.listener", "rabbitmq_web_stomp.ssl_config", [
+    {datatype, [{enum, [none]}, ip]}
+]}.
+
 {mapping, "web_stomp.ssl.port", "rabbitmq_web_stomp.ssl_config.port",
     [{datatype, integer}]}.
 {mapping, "web_stomp.ssl.backlog", "rabbitmq_web_stomp.ssl_config.backlog",
     [{datatype, integer}]}.
 {mapping, "web_stomp.ssl.ip", "rabbitmq_web_stomp.ssl_config.ip",
     [{datatype, string}, {validators, ["is_ip"]}]}.
-{mapping, "web_stomp.ssl.listener", "rabbitmq_web_stomp.ssl_config", [
-    {datatype, [{enum, [none]}, ip]}
-]}.
 {mapping, "web_stomp.ssl.certfile", "rabbitmq_web_stomp.ssl_config.certfile",
     [{datatype, string}, {validators, ["file_accessible"]}]}.
 {mapping, "web_stomp.ssl.keyfile", "rabbitmq_web_stomp.ssl_config.keyfile",
@@ -59,10 +60,21 @@
     fun(Conf) ->
         Setting = cuttlefish:conf_get("web_stomp.ssl.listener", Conf, undefined),
         case Setting of
-            none -> [];
+            none      -> cuttlefish:unset();
             undefined -> [];
             {Ip, Port} when is_list(Ip), is_integer(Port) ->
-                [{ip, Ip}, {port, Port}]
+                %% we redo some of Cuttlefish's work here to
+                %% populate rabbitmq_web_stomp.ssl_config here
+                TLSConf   = cuttlefish_variable:filter_by_prefix("web_stomp.ssl", Conf),
+                %% preserve all web_stomp.ssl.* keys in rabbitmq_web_stomp.ssl_config
+                TLSConfM0 = maps:fold(fun(Path, V, Acc) ->
+                                              maps:put(list_to_atom(lists:last(Path)), V, Acc)
+                                      end, #{}, maps:from_list(TLSConf)),
+                TLSConfM  = maps:remove(listener, TLSConfM0),
+                ListenerM = maps:from_list([{ip, Ip}, {port, Port}]),
+                lists:keysort(1, maps:to_list(maps:merge(TLSConfM, ListenerM)));
+
+            _         -> Setting
         end
     end
 }.

--- a/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
@@ -26,8 +26,25 @@
   [rabbitmq_web_stomp]},
  {ssl_listener_none,
   "web_stomp.ssl.listener = none",
+  [],
+  [rabbitmq_web_stomp]},
+
+ {ssl_with_listener,
+  "web_stomp.ssl.listener   = 127.0.0.2:15671
+   web_stomp.ssl.backlog    = 1024
+   web_stomp.ssl.certfile   = test/config_schema_SUITE_data/certs/cert.pem
+   web_stomp.ssl.keyfile    = test/config_schema_SUITE_data/certs/key.pem
+   web_stomp.ssl.cacertfile = test/config_schema_SUITE_data/certs/cacert.pem
+   web_stomp.ssl.password   = changeme",
   [{rabbitmq_web_stomp,
-    [{ssl_config, []}]}],
+       [{ssl_config,
+            [{ip,"127.0.0.2"},
+             {port,15671},
+             {backlog,1024},
+             {certfile,"test/config_schema_SUITE_data/certs/cert.pem"},
+             {keyfile,"test/config_schema_SUITE_data/certs/key.pem"},
+             {cacertfile,"test/config_schema_SUITE_data/certs/cacert.pem"},
+             {password,"changeme"}]}]}],
   [rabbitmq_web_stomp]},
 
  {ssl,


### PR DESCRIPTION
Same idea as in https://github.com/rabbitmq/rabbitmq-web-mqtt/pull/49.

Closes #104, references rabbitmq/rabbitmq-web-mqtt#48.