### PR TITLE
Allow fallback to default_login when using a CONNECT frame

### DIFF
--- a/src/rabbit_ws_handler.erl
+++ b/src/rabbit_ws_handler.erl
@@ -97,13 +97,13 @@ init_processor_state(#state{socket=Sock, peername=PeerAddr, auth_hd=AuthHd}) ->
 
     UseHTTPAuth = application:get_env(rabbitmq_web_stomp, use_http_auth, false),
     StompConfig0 = #stomp_configuration{implicit_connect = false},
+    UserConfig = application:get_env(rabbitmq_stomp, default_user, undefined),
+    StompConfig1 = rabbit_stomp:parse_default_user(UserConfig, StompConfig0),
     StompConfig = case UseHTTPAuth of
         true ->
             case AuthHd of
                 undefined ->
                     %% We fall back to the default STOMP credentials.
-                    UserConfig = application:get_env(rabbitmq_stomp, default_user, undefined),
-                    StompConfig1 = rabbit_stomp:parse_default_user(UserConfig, StompConfig0),
                     StompConfig1#stomp_configuration{force_default_creds = true};
                 _ ->
                     {basic, HTTPLogin, HTTPPassCode}
@@ -114,7 +114,7 @@ init_processor_state(#state{socket=Sock, peername=PeerAddr, auth_hd=AuthHd}) ->
                       force_default_creds = true}
             end;
         false ->
-            StompConfig0
+            StompConfig1
     end,
 
     AdapterInfo = amqp_connection:socket_adapter_info(Sock, {'Web STOMP', 0}),


### PR DESCRIPTION
When the STOMP `default_login` is set and a `CONNECT` frame is sent via a WebSocket without credentials the connection fails with bad login. This is because  `rabbitmq-web-stomp` does not forward the `default_login` to `rabbitmq-stomp` as part of the state.

If `use_http_auth` is set to `true` this state is passed to `rabbitmq-stomp` but then the credentials in the `CONNECT` frame are ignored and the `default_login` is always used if no HTTP Authorization header is set.

This pull request slightly modifies the flow to also send the `default_login` to `rabbitmq-stomp` even if `use_http_auth` is `false`. In this way one can use a `CONNECT` frame both with credentials and without (falling back to the default user if configured).