### PR TITLE
Expose use_http_auth in new style config schema

### DIFF
--- a/priv/schema/rabbitmq_web_stomp.schema
+++ b/priv/schema/rabbitmq_web_stomp.schema
@@ -25,6 +25,9 @@
 {mapping, "web_stomp.ws_path", "rabbitmq_web_stomp.ws_path",
     [{datatype, string}]}.
 
+{mapping, "web_stomp.use_http_auth", "rabbitmq_web_stomp.use_http_auth",
+    [{datatype, {enum, [true, false]}}]}.
+
 {translation,
     "rabbitmq_web_stomp.tcp_config",
     fun(Conf) ->

--- a/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_web_stomp.snippets
@@ -157,6 +157,11 @@
   [{rabbitmq_web_stomp,[{ws_frame,binary}]}],
   [rabbitmq_web_stomp]},
 
+ {use_http_auth,
+  "web_stomp.use_http_auth = true",
+  [{rabbitmq_web_stomp,[{use_http_auth, true}]}],
+  [rabbitmq_web_stomp]},
+
  %%
  %% Cowboy options
  %%


### PR DESCRIPTION
as `web_stomp.use_http_auth`.

Closes #119