### PR TITLE
Stop on errors

### DIFF
--- a/src/rabbit_web_stomp_handler.erl
+++ b/src/rabbit_web_stomp_handler.erl
@@ -279,7 +279,7 @@ stop(State = #state{proc_state = ProcState}, CloseCode, Error) ->
     maybe_emit_stats(State),
     ok = file_handle_cache:release(),
     rabbit_stomp_processor:flush_and_die(ProcState),
-    {reply, {close, CloseCode, Error}, State}.
+    {[{close, CloseCode, Error}], State}.
 
 %%----------------------------------------------------------------------------
 

--- a/src/rabbit_web_stomp_handler.erl
+++ b/src/rabbit_web_stomp_handler.erl
@@ -234,6 +234,8 @@ handle_data(Data, State0) ->
     case handle_data1(Data, State0) of
         {ok, State1 = #state{state = blocked}} ->
             {[{active, false}], State1};
+        {error, _}=Error ->
+            {stop, State0};
         Other ->
             Other
     end.
@@ -257,7 +259,9 @@ handle_data1(Bytes, State = #state{proc_state  = ProcState,
                                      connection  = ConnPid });
                 {stop, _Reason, ProcState1} ->
                     stop(State#state{ proc_state = ProcState1 })
-            end
+            end;
+        Other ->
+            Other
     end.
 
 maybe_block(State = #state{state = blocking, heartbeat = Heartbeat},

--- a/src/rabbit_web_stomp_handler.erl
+++ b/src/rabbit_web_stomp_handler.erl
@@ -234,7 +234,7 @@ handle_data(Data, State0) ->
     case handle_data1(Data, State0) of
         {ok, State1 = #state{state = blocked}} ->
             {[{active, false}], State1};
-        {error, _}=Error ->
+        {error, _} ->
             {stop, State0};
         Other ->
             Other


### PR DESCRIPTION
Rather than crashing with `case_clause`, errors returned in the data
handlers should result in the orderly shutdown of the STOMP connection.

Fixes #121

@essen I'm curious, I noticed that returning `{stop, State}` is a deprecated call result:

https://github.com/ninenines/cowboy/blob/2.6.1/src/cowboy_websocket.erl#L43-L47

What will eventually be the correct way to return `stop`?