### PR TITLE
Maintenance mode event support

### DIFF
--- a/src/rabbit_web_stomp_app.erl
+++ b/src/rabbit_web_stomp_app.erl
@@ -27,5 +27,5 @@ start(_Type, _StartArgs) ->
     rabbit_web_stomp_sup:start_link().
 
 -spec stop(_) -> ok.
-stop(_State) ->
-    ok.
+stop(State) ->
+    rabbit_web_stomp_listener:stop(State).

--- a/src/rabbit_web_stomp_app.erl
+++ b/src/rabbit_web_stomp_app.erl
@@ -24,6 +24,11 @@
 -spec start(_, _) -> {ok, pid()}.
 start(_Type, _StartArgs) ->
     ok = rabbit_web_stomp_listener:init(),
+    EMPid = case rabbit_event:start_link() of
+              {ok, Pid}                       -> Pid;
+              {error, {already_started, Pid}} -> Pid
+            end,
+    gen_event:add_handler(EMPid, rabbit_web_stomp_internal_event_handler, []),
     rabbit_web_stomp_sup:start_link().
 
 -spec stop(_) -> ok.

--- a/src/rabbit_web_stomp_handler.erl
+++ b/src/rabbit_web_stomp_handler.erl
@@ -22,11 +22,14 @@
 -include_lib("amqp_client/include/amqp_client.hrl").
 
 %% Websocket.
--export([init/2]).
--export([websocket_init/1]).
--export([websocket_handle/2]).
--export([websocket_info/2]).
--export([terminate/3]).
+-export([
+    init/2,
+    websocket_init/1,
+    websocket_handle/2,
+    websocket_info/2,
+    terminate/3
+]).
+-export([close_connection/2]).
 
 -record(state, {
     frame_type,
@@ -87,6 +90,13 @@ websocket_init(State) ->
            State#state{proc_state     = ProcessorState,
                        parse_state    = rabbit_stomp_frame:initial_state()},
            #state.stats_timer)}.
+
+-spec close_connection(pid(), string()) -> 'ok'.
+close_connection(Pid, Reason) ->
+    rabbit_log_connection:info("Web STOMP: will terminate connection process ~p, reason: ~s",
+                               [Pid, Reason]),
+    sys:terminate(Pid, Reason),
+    ok.
 
 init_processor_state(#state{socket=Sock, peername=PeerAddr, auth_hd=AuthHd}) ->
     Self = self(),

--- a/src/rabbit_web_stomp_internal_event_handler.erl
+++ b/src/rabbit_web_stomp_internal_event_handler.erl
@@ -1,0 +1,46 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License
+%% at https://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+%% the License for the specific language governing rights and
+%% limitations under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(rabbit_web_stomp_internal_event_handler).
+
+-behaviour(gen_event).
+
+-export([init/1, handle_event/2, handle_call/2, handle_info/2, terminate/2, code_change/3]).
+
+-import(rabbit_misc, [pget/2]).
+
+init([]) ->
+  {ok, []}.
+
+handle_event({event, maintenance_connections_closed, _Info, _, _}, State) ->
+  %% we should close our connections
+  {ok, NConnections} = rabbit_web_stomp_listener:close_all_client_connections("node is being put into maintenance mode"),
+  rabbit_log:alert("Closed ~b local Web STOMP client connections", [NConnections]),
+  {ok, State};
+handle_event(_Event, State) ->
+  {ok, State}.
+
+handle_call(_Request, State) ->
+  {ok, State}.
+
+handle_info(_Info, State) ->
+  {ok, State}.
+
+terminate(_Reason, _State) ->
+  ok.
+
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.

--- a/src/rabbit_web_stomp_listener.erl
+++ b/src/rabbit_web_stomp_listener.erl
@@ -60,8 +60,8 @@ init() ->
     ok.
 
 stop(State) ->
-    stop_ranch_listener(?TCP_PROTOCOL),
-    stop_ranch_listener(?TLS_PROTOCOL),
+    rabbit_networking:stop_ranch_listener_of_protocol(?TCP_PROTOCOL),
+    rabbit_networking:stop_ranch_listener_of_protocol(?TLS_PROTOCOL),
     State.
 
 -spec list_connections() -> [pid()].
@@ -81,13 +81,6 @@ close_all_client_connections(Reason) ->
 %%
 %% Implementation
 %%
-
-stop_ranch_listener(Protocol) ->
-    case rabbit_networking:ranch_ref_of_protocol(Protocol) of
-        {error, not_found} -> ok;
-        undefined          -> ok;
-        Ref                -> ranch:stop_listener(Ref)
-    end.
 
 connection_pids_of_protocol(Protocol) ->
     case rabbit_networking:ranch_ref_of_protocol(Protocol) of

--- a/test/src/rabbit_ws_test_util.erl
+++ b/test/src/rabbit_ws_test_util.erl
@@ -26,11 +26,6 @@ update_app_env(Config, Key, Val) ->
                                       application, stop,
                                       [rabbitmq_web_stomp]),
     ok = rabbit_ct_broker_helpers:rpc(Config, 0,
-                                      ranch, stop_listener,
-                                      [web_stomp]),
-    rabbit_ct_broker_helpers:rpc(Config, 0, ranch, stop_listener,
-                                      [web_stomp_secure]),
-    ok = rabbit_ct_broker_helpers:rpc(Config, 0,
                                       application, start,
                                       [rabbitmq_web_stomp]).
 


### PR DESCRIPTION
This makes the refs predictable and easy to compute
from a listener record. Then suspending all listeners
becomes a lot simpler.

We also introduce a way to list and shut down all Web STOMP client
connections. Kudos to @essen for explaining what'd be the best way to do that
with Ranch.

While at it, make protocol applications clean up
their listeners when they stop. This way tests
and other callers that have to stop the app
would not need to know anything about
its listeners.

Part of rabbitmq/rabbitmq-server#2321